### PR TITLE
chore(eslint): ignore packages dir (#4963)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ scripts
 updates
 artifacts
 dist
+packages


### PR DESCRIPTION
### Summary

With this pull request, we present a solution for issue [#4769](https://github.com/yarnpkg/yarn/issues/4769). 

**Motivation:** Besides being a good beginner issue to start understanding yarn, this PR is useful for users trying to consume the json output of `yarn licenses list --json --no-progress` or `yarn licenses list --json` by including the license disclaimer text in the JSON output. 
**Solves:** Issue [#4769](https://github.com/yarnpkg/yarn/issues/4769). According to which users should also receive the license text in the licenses listing in JSON format. 
### Test plan
The changes were simple enough and it was tested on yarn itself, returning the license text where present and Undefined otherwise.